### PR TITLE
Added button to close the end task window

### DIFF
--- a/code/meteor_app/imports/ui/body.html
+++ b/code/meteor_app/imports/ui/body.html
@@ -168,7 +168,9 @@
         <div class="modal-content ">
           <div class="modal-header">
             <h5 class="modal-title" id="taskCompleteModal">Task Complete!</h5>
-
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
           </div>
           <div class="modal-body" style="height:80vh">
             <!-- On the hidden, test dataset, the pattern matches {{recallOnTestSet}}% of the misuses.  -->


### PR DESCRIPTION
# User Story
Implements the functionality as described in User Story #1. This PR Closes #1

# Old Functionality
When clicking the end task button, a window would pop up saying "Task Completed!", without any way of closing out, other than refreshing the page.

# New Functionality
The "Task Completed!" window now has an X in the upper right corner that closes the window when clicked.

# Related Issues
Close #3 
